### PR TITLE
更新：在 apphosting.yaml 中移除 Google Maps API 金鑰環境變數，並在 AddressSelector.ts…

### DIFF
--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -66,8 +66,3 @@ env:
     availability:
       - BUILD
       - RUNTIME
-  - variable: NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
-    value: "AIzaSyBdgNEAkXT0pCWOkSK7xXoAcUsOWbJEz8o"
-    availability:
-      - BUILD
-      - RUNTIME

--- a/src/components/common/AddressSelector.tsx
+++ b/src/components/common/AddressSelector.tsx
@@ -46,7 +46,7 @@ export default function AddressSelector({
             setIsLoading(true);
             try {
                 const loader = new Loader({
-                    apiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || "",
+                    apiKey: "AIzaSyBdgNEAkXT0pCWOkSK7xXoAcUsOWbJEz8o",
                     version: "weekly",
                     libraries: ["places"]
                 });


### PR DESCRIPTION
…x 中直接使用該金鑰，簡化配置，提升代碼可讀性。